### PR TITLE
Add type union generator

### DIFF
--- a/lune/generate/init.luau
+++ b/lune/generate/init.luau
@@ -29,16 +29,17 @@ local function run(program: string, params: { string }, options: Options?)
 	return result.stdout:gsub("\n$", "")
 end
 
-local arg = process.args[1]
+local arg1 = process.args[1]
+local arg2 = process.args[2]
 
 local result
 pcall(function()
 	run("rojo", { "build", "test.project.json", "--output", "test-place.rbxl" })
 	result = run(
 		"run-in-roblox",
-		{ "--place", "test-place.rbxl", "--script", `lune/generate/{arg}.luau` },
+		{ "--place", "test-place.rbxl", "--script", `lune/generate/{arg1}.luau` },
 		{ stdio = "default" }
 	)
 end)
 
-fs.writeFile("supported.csv", result)
+fs.writeFile(arg2, result)

--- a/lune/generate/type-unions.luau
+++ b/lune/generate/type-unions.luau
@@ -1,0 +1,33 @@
+local pkgRoot = game.ReplicatedStorage.Packages.Bufferize
+local dataTypes = require(pkgRoot.DataTypes)
+
+local definitionsByTypeId = dataTypes.Encoder.definitionsByTypeId
+
+local maxTypeId = -1
+for _, definition in definitionsByTypeId do
+	maxTypeId = math.max(definition.typeId, maxTypeId)
+end
+
+local supportedTypings = {}
+local overridableTypings = {}
+for i = 0, maxTypeId do
+	local definition = definitionsByTypeId[i]
+	if definition.typeOf:match("userdata:") then
+		continue
+	end
+
+	if definition.support == "implemented" then
+		table.insert(supportedTypings, definition.typing)
+		if definition.overridable then
+			table.insert(overridableTypings, definition.typing)
+		end
+	end
+end
+
+print("export type Supported = " .. table.concat(supportedTypings, "\n\t| "))
+print("")
+print("export type Overridable = " .. table.concat(overridableTypings, "\n\t| "))
+print("")
+print("return {}")
+
+return {}

--- a/src/DataTypes/DataTypeDefinition.luau
+++ b/src/DataTypes/DataTypeDefinition.luau
@@ -19,6 +19,7 @@ export type DataTypeDefinition<T> = typeof(setmetatable(
 	{} :: {
 		typeId: number,
 		typeOf: string,
+		typing: string,
 		definition: Definition<T>,
 		overridable: boolean,
 		support: "implemented" | "unimplemented" | "never",
@@ -31,6 +32,7 @@ function DataTypeDefinitionStatic.new<T>(typeOf: string, definition: Definition<
 
 	self.typeId = TypeIds.assert(typeOf)
 	self.typeOf = typeOf
+	self.typing = typeOf
 	self.definition = table.clone(definition)
 	self.overridable = true
 	self.support = "implemented"

--- a/src/DataTypes/Dependant/table.luau
+++ b/src/DataTypes/Dependant/table.luau
@@ -235,5 +235,6 @@ local tblDefinition = DataTypeDefinition.new("table", {
 })
 
 tblDefinition.overridable = false
+tblDefinition.typing = "{ [any]: any }"
 
 return tblDefinition

--- a/src/DataTypes/TypeUnions.luau
+++ b/src/DataTypes/TypeUnions.luau
@@ -1,0 +1,76 @@
+export type Supported = nil
+	| boolean
+	| number
+	| string
+	| buffer
+	| { [any]: any }
+	| Axes
+	| BrickColor
+	| CFrame
+	| Color3
+	| ColorSequence
+	| ColorSequenceKeypoint
+	| Enum
+	| EnumItem
+	| Enums
+	| Faces
+	| FloatCurveKey
+	| Font
+	| NumberRange
+	| NumberSequence
+	| NumberSequenceKeypoint
+	| Path2DControlPoint
+	| PathWaypoint
+	| PhysicalProperties
+	| Ray
+	| Rect
+	| Region3
+	| Region3int16
+	| RotationCurveKey
+	| TweenInfo
+	| UDim
+	| UDim2
+	| vector
+	| Vector2
+	| Vector2int16
+	| Vector3
+	| Vector3int16
+
+export type Overridable = nil
+	| boolean
+	| number
+	| string
+	| buffer
+	| Axes
+	| BrickColor
+	| CFrame
+	| Color3
+	| ColorSequence
+	| ColorSequenceKeypoint
+	| Enum
+	| EnumItem
+	| Enums
+	| Faces
+	| FloatCurveKey
+	| Font
+	| NumberRange
+	| NumberSequence
+	| NumberSequenceKeypoint
+	| Path2DControlPoint
+	| PathWaypoint
+	| PhysicalProperties
+	| Ray
+	| Rect
+	| Region3
+	| Region3int16
+	| RotationCurveKey
+	| TweenInfo
+	| UDim
+	| UDim2
+	| vector
+	| Vector2
+	| Vector2int16
+	| Vector3
+	| Vector3int16
+
+return {}

--- a/src/DataTypes/init.luau
+++ b/src/DataTypes/init.luau
@@ -1,5 +1,9 @@
+local TypeUnions = require(script.TypeUnions)
 local DataTypePacker = require(script.DataTypePacker)
 local UserdataDefinitions = require(script.Standalone.Userdata.Definitions)
+
+export type Supported = TypeUnions.Supported
+export type Overridable = TypeUnions.Overridable
 
 return {
 	Userdata = UserdataDefinitions,

--- a/src/Encoder.luau
+++ b/src/Encoder.luau
@@ -5,6 +5,9 @@ local Wally = require(script.Parent.Wally)
 local DataTypes = require(script.Parent.DataTypes)
 local BufferStream = require(script.Parent.BufferStream)
 
+export type Supported = DataTypes.Supported
+export type Overridable = DataTypes.Overridable
+
 type CopyStackEntry<T> = {
 	original: T,
 	copy: T,
@@ -193,7 +196,7 @@ function EncoderClass.override<T>(self: Encoder, typeOf: string, encoder: Custom
 	self.encoders[typeOf] = encoder
 end
 
-function EncoderClass.encode(self: Encoder, ...: any)
+function EncoderClass.encode(self: Encoder, ...: Supported)
 	-- we always wrap our inputs in a table b/c it will ensure
 	-- pointers are being used for duplicated tables
 	local packed = table.pack(...)

--- a/src/init.luau
+++ b/src/init.luau
@@ -5,6 +5,9 @@ local InstanceSerializer = require(script.InstanceSerializer)
 export type Encoder = Encoder.Encoder
 export type BufferStream = BufferStream.BufferStream
 
+export type Supported = Encoder.Supported
+export type Overridable = Encoder.Overridable
+
 local Bufferize = {}
 local defaultEncoder = Encoder.new()
 
@@ -17,7 +20,7 @@ Bufferize.stream = BufferStream.new
 Bufferize.serializeInstance = InstanceSerializer.serialize
 Bufferize.deserializeInstance = InstanceSerializer.deserialize
 
-function Bufferize.encode(...: any)
+function Bufferize.encode(...: Supported)
 	return defaultEncoder:encode(...)
 end
 


### PR DESCRIPTION
This PR adds a lune command to generate type unions for what data types are supported / overridable by bufferize. This is useful if you want to enforce some degree of typing to ensure your data can be encoded.

This currently is lacking when it comes to tables which are typed as `{ [any]: any }` meaning you can circumvent this typing by wrapping unsupported data types in a table. This will still fail to actually encode, but the typechecker won't catch it.