### PR TITLE
Add instance tag serialization

### DIFF
--- a/src/Serializers/InstanceSerializer.luau
+++ b/src/Serializers/InstanceSerializer.luau
@@ -5,7 +5,7 @@ local pointerUserdata = DataTypes.Userdata.InstancePointer
 
 local InstanceSerializer = {}
 
-function InstanceSerializer.shouldSerializeProperty(property: { [string]: any })
+local function shouldSerializeProperty(property: { [string]: any })
 	return property.Permits
 		and property.Permits.Read
 		and property.Permits.Write
@@ -46,7 +46,7 @@ function InstanceSerializer.serialize(rootInstance: Instance)
 
 		local j = 2
 		for _, property in properties do
-			local shouldSerialize = InstanceSerializer.shouldSerializeProperty(property)
+			local shouldSerialize = shouldSerializeProperty(property)
 			if shouldSerialize and not (instance == rootInstance and property.Name == "Parent") then
 				local success, err = pcall(function()
 					local value = instanceAny[property.Name]
@@ -76,8 +76,15 @@ function InstanceSerializer.serialize(rootInstance: Instance)
 			j = j + 2
 		end
 
+		local k = 0
+		for _, tagName in instance:GetTags() do
+			k = k + 1
+			serialized[j + 1 + k] = tagName
+		end
+
 		defaultInstance:Destroy()
 
+		serialized[j + 1] = if k > 0 then k else nil
 		serialized[2] = (j - 2) // 2
 		serializedArr[pointer.value.index] = serialized
 	end
@@ -91,14 +98,15 @@ function InstanceSerializer.deserialize(serializedArr: { any })
 	for i, serialized in serializedArr do
 		local className = serialized[1]
 		local keyValueCount = serialized[2] * 2
+		local tagCount = serialized[3 + keyValueCount] or 0
 
 		local instance = Instance.new(className)
 		local instanceAny = instance :: any
 
 		local isAttribute = false
-		for i = 1, keyValueCount, 2 do
-			local key = serialized[i + 2]
-			local value = serialized[i + 3]
+		for j = 1, keyValueCount, 2 do
+			local key = serialized[j + 2]
+			local value = serialized[j + 3]
 
 			if pointerUserdata:isTypeOf(value) then
 				local pointer = pointerUserdata:read(value)
@@ -111,6 +119,11 @@ function InstanceSerializer.deserialize(serializedArr: { any })
 			else
 				instanceAny[key] = value
 			end
+		end
+
+		for j = 1, tagCount do
+			local tagName = serialized[3 + keyValueCount + j]
+			instance:AddTag(tagName)
 		end
 
 		instances[i] = instance

--- a/src/Serializers/InstanceSerializer.spec.luau
+++ b/src/Serializers/InstanceSerializer.spec.luau
@@ -44,6 +44,19 @@ createTestInstance(function()
 	return root
 end)
 
+createTestInstance(function()
+	local root = Instance.new("Model")
+	root:AddTag("TagA")
+	local partA = Instance.new("Part", root)
+	partA:AddTag("TagB")
+	local partB = Instance.new("WedgePart", root)
+	partB.Size = Vector3.new(math.pi, 10, 1000.78)
+	local valPointer = Instance.new("ObjectValue", partB)
+	valPointer:AddTag("TagB")
+	valPointer.Parent = partA
+	return root
+end)
+
 --
 
 TestHelper.values(table.pack(table.unpack(testInstances)), function(instance)

--- a/wally.toml
+++ b/wally.toml
@@ -2,7 +2,7 @@
 name = "egomoose/bufferize"
 description = "A tool to losslessly encode / decode roblox data types to buffers."
 repository = "https://github.com/EgoMoose/rbx-bufferize"
-version = "2.0.0"
+version = "2.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"

--- a/wally.toml
+++ b/wally.toml
@@ -2,7 +2,7 @@
 name = "egomoose/bufferize"
 description = "A tool to losslessly encode / decode roblox data types to buffers."
 repository = "https://github.com/EgoMoose/rbx-bufferize"
-version = "2.1.0"
+version = "2.1.0-pre"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
This PR adds support for tags to the instance serializer. This is a backwards compatible change and was relatively simple to implement.