### PR TITLE
Add isCompatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ For example, say you used bufferize v1.0.0 to store data in a datastore and then
 
 This means in practice that when a major version of bufferize releases old data will not be compatible. When the minor or patch version changes you can decode your old data with the new version of bufferize, but you can't decode your new data with the old version.
 
+If you'd rather branch on compatibility than handle an error you can check a buffer before decoding it. `Bufferize.isCompatible` runs the same version check that `decode` does, so a `false` result means `decode` would throw.
+
+```luau
+if Bufferize.isCompatible(b) then
+	local value = Bufferize.decode(b)
+else
+	print(`cannot decode a buffer from version {Bufferize.readVersion(b)} with version {Bufferize.VERSION}`)
+end
+```
+
+Only the header is read, so a `true` result doesn't promise the rest of the buffer is well-formed. Buffers that weren't produced by `encode` at all return `false`.
+
 ## Supported DataTypes
 
 | **DataType**                | **Supported** | **Overridable** |

--- a/src/Encoder.luau
+++ b/src/Encoder.luau
@@ -56,6 +56,26 @@ end
 
 local WALLY_SEMVER = getWallySemVer()
 
+local function readHeaderVersion(stream: BufferStream.BufferStream)
+	local length = stream:readu8()
+	local wallyVersion = stream:readString(length)
+	return CargoSemver.Version.parse(wallyVersion)
+end
+
+local function assertCompatibleHeader(stream: BufferStream.BufferStream)
+	local headerVer = assert(readHeaderVersion(stream), "Failed to read header version.")
+
+	assert(
+		headerVer >= WALLY_SEMVER.majorVer and headerVer < WALLY_SEMVER.nextMajorVer,
+		`Attempted to decode a buffer encoded with a different major version '{headerVer}'.`
+	)
+
+	assert(
+		headerVer <= WALLY_SEMVER.ver,
+		`Attempted to decode a buffer encoded with a newer version of Bufferize '{headerVer}'.`
+	)
+end
+
 local function encodeInternal(rootTbl: { [any]: any }, encoders: { [string]: CustomEncoder<any> })
 	if next(encoders) then
 		local stack = {} :: { CopyStackEntry<any> }
@@ -119,21 +139,7 @@ end
 
 local function decodeInternal(b: buffer, encoders: { [string]: CustomEncoder<any> })
 	local stream = BufferStream.static(b)
-	local length = stream:readu8()
-	local wallyVersion = stream:readString(length)
-
-	local headerVer = assert(CargoSemver.Version.parse(wallyVersion), "Failed to read header version.")
-	assert(
-		headerVer >= WALLY_SEMVER.majorVer and headerVer < WALLY_SEMVER.nextMajorVer,
-		`Attempted to decode a buffer encoded with a different major version '{headerVer}'.`
-	)
-
-	assert(
-		headerVer <= WALLY_SEMVER.ver,
-		`Attempted to decode a buffer encoded with a newer version of Bufferize '{headerVer}'.`
-	)
-
-	-- also don't want the version to be greater than WALLY_SEMVER.ver
+	assertCompatibleHeader(stream)
 
 	local rootTbl = DataTypes.Encoder:readStream(stream)
 
@@ -245,11 +251,23 @@ end
 	the body. See [Bufferize.readVersion].
 ]=]
 function EncoderStatic.readVersion(b: buffer)
-	local stream = BufferStream.static(b)
-	local length = stream:readu8()
-	local wallyVersion = stream:readString(length)
-	local ver = CargoSemver.Version.parse(wallyVersion)
-	return if ver then tostring(ver) else nil
+	local success, ver = pcall(readHeaderVersion, BufferStream.static(b))
+	return if success and ver then tostring(ver) else nil
+end
+
+--[=[
+	@within Encoder
+	@function isCompatible
+	@param b buffer -- A buffer previously produced by an encoder's `encode` method.
+	@return boolean -- Whether the running version of Bufferize is able to decode the buffer.
+
+	Checks whether the version written into the buffer's header is compatible
+	with the running version of Bufferize, i.e. whether `decode` will accept it
+	rather than raising a version error. See [Bufferize.isCompatible].
+]=]
+function EncoderStatic.isCompatible(b: buffer)
+	local success = pcall(assertCompatibleHeader, BufferStream.static(b))
+	return success
 end
 
 --[=[

--- a/src/Encoder.spec.luau
+++ b/src/Encoder.spec.luau
@@ -1,0 +1,76 @@
+local JestGlobals = require(game.ReplicatedStorage.DevPackages.JestGlobals)
+
+local it = JestGlobals.it
+local expect = JestGlobals.expect
+local describe = JestGlobals.describe
+
+local bufferizeRoot = script.Parent
+local Bufferize = require(bufferizeRoot)
+
+local function headerOnly(version: string)
+	local b = buffer.create(1 + #version)
+	buffer.writeu8(b, 0, #version)
+	buffer.writestring(b, 1, version)
+	return b
+end
+
+local majorStr, minorStr, patchStr = string.match(Bufferize.VERSION, "^(%d+)%.(%d+)%.(%d+)")
+local MAJOR = assert(tonumber(majorStr), "Failed to read the running major version.")
+local MINOR = assert(tonumber(minorStr), "Failed to read the running minor version.")
+local PATCH = assert(tonumber(patchStr), "Failed to read the running patch version.")
+
+describe("isCompatible", function()
+	it("should accept a buffer encoded by the running version.", function()
+		local b = Bufferize.encode("Hello world!", 123, true, { foo = "bar" })
+		expect(Bufferize.isCompatible(b)).toEqual(true)
+	end)
+
+	it("should accept an older version within the same major version.", function()
+		expect(Bufferize.isCompatible(headerOnly(`{MAJOR}.0.0`))).toEqual(true)
+	end)
+
+	it("should reject a newer version within the same major version.", function()
+		expect(Bufferize.isCompatible(headerOnly(`{MAJOR}.{MINOR}.{PATCH + 1}`))).toEqual(false)
+	end)
+
+	it("should reject a newer major version.", function()
+		expect(Bufferize.isCompatible(headerOnly(`{MAJOR + 1}.0.0`))).toEqual(false)
+	end)
+
+	if MAJOR > 0 then
+		it("should reject an older major version.", function()
+			expect(Bufferize.isCompatible(headerOnly(`{MAJOR - 1}.0.0`))).toEqual(false)
+		end)
+	end
+
+	it("should reject a malformed version header.", function()
+		expect(Bufferize.isCompatible(headerOnly("not.a.version"))).toEqual(false)
+	end)
+
+	it("should reject an empty buffer.", function()
+		expect(Bufferize.isCompatible(buffer.create(0))).toEqual(false)
+	end)
+
+	it("should reject a buffer that was not produced by encode.", function()
+		expect(Bufferize.isCompatible(buffer.fromstring("this was never a bufferize buffer"))).toEqual(false)
+	end)
+
+	it("should agree with decode.", function()
+		local b = Bufferize.encode("Hello world!")
+		expect(Bufferize.isCompatible(b)).toEqual(pcall(Bufferize.decode, b))
+
+		local incompatible = headerOnly(`{MAJOR + 1}.0.0`)
+		expect(Bufferize.isCompatible(incompatible)).toEqual(pcall(Bufferize.decode, incompatible))
+	end)
+end)
+
+describe("readVersion", function()
+	it("should read back the running version.", function()
+		expect(Bufferize.readVersion(Bufferize.encode("Hello world!"))).toEqual(Bufferize.VERSION)
+	end)
+
+	it("should return nil for a buffer that was not produced by encode.", function()
+		expect(Bufferize.readVersion(buffer.create(0))).toEqual(nil)
+		expect(Bufferize.readVersion(headerOnly("not.a.version"))).toEqual(nil)
+	end)
+end)

--- a/src/init.luau
+++ b/src/init.luau
@@ -55,6 +55,31 @@ Bufferize.readVersion = Encoder.readVersion
 
 --[=[
 	@within Bufferize
+	@function isCompatible
+	@tag Versioning
+	@param b buffer -- A buffer previously produced by `Bufferize.encode`.
+	@return boolean -- `true` if the buffer's header version can be decoded by the running version of Bufferize.
+
+	Checks whether the running version of Bufferize is able to decode the given
+	buffer. This is the same version check `decode` performs, so a `false` result
+	means `decode` would raise an error rather than return a value.
+
+	```lua
+	if Bufferize.isCompatible(b) then
+		local value = Bufferize.decode(b)
+	else
+		-- migrate the data with an older version, or discard it
+	end
+	```
+
+	Only the version header is inspected — the body is not decoded, so a `true`
+	result does not guarantee the rest of the buffer is well-formed. Buffers that
+	were not produced by `encode` at all return `false`.
+]=]
+Bufferize.isCompatible = Encoder.isCompatible
+
+--[=[
+	@within Bufferize
 	@function custom
 	@return Encoder -- A new encoder with no overrides registered.
 


### PR DESCRIPTION
Adds a quick way to check if the buffer you're using is compatible with the current version of bufferize.